### PR TITLE
Statistical: n-squared denominators in double (Int32 overflow above 46,340)

### DIFF
--- a/source/Statistical.cs
+++ b/source/Statistical.cs
@@ -16,14 +16,18 @@ public static class Statistical
 		// (sum2 - sum * sum / n) / (n - 1) // Sample
 
 		// Reduce the amount of division in order to reduce the amount of double precision error.
+		// The n·n product must be computed in double: as Int32 it overflows for any n above
+		// 46,340 (and at n = 2^20 wraps to exactly zero, turning the term into an infinity).
+		// For every n it does not overflow at, the product is an exactly representable double,
+		// so results at those sizes are unchanged bit for bit.
 		if (!sample)
-			return sum2 / n - sum * sum / (n * n);
+			return sum2 / n - sum * sum / ((double)n * n);
 
 		if (n == 1)
 			return double.NaN; // Avoid divide by zero.
 
 		var n1 = n - 1;
-		var n2 = n * n1;
+		var n2 = (double)n * n1;
 
 		return sum2 / n1 - sum * sum / n2;
 	}
@@ -222,11 +226,13 @@ public static class Statistical
 
 	static double Covariance(int n, double sumA, double sumB, double prod, bool sample)
 	{
+		// The n·n product in double for the same reason as Variance above: Int32 overflows for
+		// any n above 46,340, and identical values everywhere it does not.
 		if (!sample)
-			return prod / n - sumA * sumB / (n * n);
+			return prod / n - sumA * sumB / ((double)n * n);
 
 		var n2 = n - 1;
-		return prod / n2 - sumA * sumB / (n * n2);
+		return prod / n2 - sumA * sumB / ((double)n * n2);
 	}
 
 	/// <summary>

--- a/tests/Statistical.cs
+++ b/tests/Statistical.cs
@@ -57,4 +57,31 @@ public class Statistical
 			Assert.AreEqual(1, same.Correlation(same));
 		}
 	}
+
+	[TestMethod]
+	public void LargeSampleSizes_DoNotOverflow()
+	{
+		// The n·n term overflows Int32 for any n above 46,340; at n = 2^20 it wrapped to exactly
+		// zero, so variance became infinite and correlation NaN. Alternating 0/1 values make every
+		// intermediate sum an exact power of two, so the expected values are exact, not approximate:
+		// population variance 0.25, self-correlation 1.
+		var values = new double[1 << 20];
+		for (var i = 0; i < values.Length; i++)
+			values[i] = i % 2;
+
+		Assert.AreEqual(0.25, values.Variance());
+		Assert.AreEqual(1, values.Correlation(values));
+
+		// Sample (n − 1) denominators take the n·(n − 1) path.
+		var sampleVariance = values.Variance(true);
+		Assert.IsTrue(sampleVariance.IsNearEqual(0.25, 6));
+
+		// The smallest overflowing count: 46,341² exceeds Int32.MaxValue.
+		var threshold = new double[46_341];
+		for (var i = 0; i < threshold.Length; i++)
+			threshold[i] = i % 2;
+
+		Assert.IsTrue(threshold.Variance().IsNearEqual(0.25, 6));
+		Assert.AreEqual(1, threshold.Correlation(threshold));
+	}
 }


### PR DESCRIPTION
## The defect

`Variance` and `Covariance` form their combined denominator as an **Int32 product** — `n * n` (population) and `n * (n - 1)` (sample):

```csharp
return sum2 / n - sum * sum / (n * n);
```

That product overflows for any count above **46,340** (46,341² > `int.MaxValue`), silently producing wrong variances/covariances — and at exactly **2²⁰ entries** it wraps to exactly **zero**, so the term becomes an infinity and `Correlation` over a 1,048,576-row set returns `NaN`.

Found while running correlation-based fitness over full 2²⁰-row truth tables in Solve; there the popcount path already widened locally, and this is the upstream fix.

## The fix

Compute the product in `double` at all four sites (`(double)n * n`, `(double)n * n1`). Wherever the Int32 product did **not** overflow, the same integer value is exactly representable in `double`, so results at those sizes are unchanged **bit for bit** — only the previously-overflowing sizes change, from wrong to correct.

## Tests

`LargeSampleSizes_DoNotOverflow`: alternating 0/1 values keep every intermediate sum a power of two, so expectations are exact — population variance `0.25` and self-correlation `1` at 2²⁰ entries, the sample-denominator path, and the smallest overflowing count (46,341). Verified the test fails against the unfixed code and passes with the fix; full suite 4/4, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)