### PR TITLE
Version 2.0.1

### DIFF
--- a/source/Open.Arithmetic.csproj
+++ b/source/Open.Arithmetic.csproj
@@ -15,8 +15,8 @@ Part of the "Open" set of libraries.</Description>
 		<PackageProjectUrl>https://github.com/Open-NET-Libraries/Open.Arithmetic/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Open-NET-Libraries/Open.Arithmetic/</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>2.0.0</Version>
-		<PackageReleaseNotes></PackageReleaseNotes>
+		<Version>2.0.1</Version>
+		<PackageReleaseNotes>Fixes Variance/Covariance/Correlation for large counts: the n-squared denominator was an Int32 product that overflowed above 46,340 entries (NaN correlation at exactly 2^20); now computed in double, bit-identical at all previously-working sizes.</PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Bumps the package version for the fix merged in #2 (Int32 overflow in the Variance/Covariance n-squared denominators above 46,340 entries) and fills in the release notes. Patch bump: behavior is bit-identical at every previously-working size; only the overflowing sizes change, from wrong to correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)